### PR TITLE
TCM17-sofia Habilitar pines PWM

### DIFF
--- a/BSW/IoHwAb/IoHwAb_adc.c
+++ b/BSW/IoHwAb/IoHwAb_adc.c
@@ -4,7 +4,31 @@
 
 #include "IoHwAb_adc.h"
 
-static const port_pin_config_t s_adcPinConfig = {
+#define TCM_LPADC0_BASE  	ADC0
+#define TCM_LPADC1_BASE		ADC1
+#define DEMO_VREF_BASE 		VREF0
+
+// IDs de comandos LPADC (1–15 válidos)
+#define TCM_LPADC_CMDID_OUTPUT      1U   // P0_14  Output_Speed_Sensor
+#define TCM_LPADC_CMDID_FLUID       2U   // P0_22  Fluid_Trans_Temperature
+#define TCM_LPADC_CMDID_TURBINE     3U   // P1_10  Turbine_Speed_Sensor
+
+// Triggers de software (0–3 típicamente)
+#define TCM_LPADC_TRIG_OUTPUT       0U
+#define TCM_LPADC_TRIG_FLUID        1U
+#define TCM_LPADC_TRIG_TURBINE      2U
+
+#define TCM_LPADC_RESULT_MASK   (0xFFFFU)
+#define TCM_LPADC_RESULTSHIFT   (0U)
+
+#define DEMO_LPADC_VREF_SOURCE           kLPADC_ReferenceVoltageAlt3
+#define DEMO_LPADC_DO_OFFSET_CALIBRATION true
+#define DEMO_LPADC_OFFSET_VALUE_A        0x10U
+#define DEMO_LPADC_OFFSET_VALUE_B        0x10U
+
+#define DEMO_SPC_BASE           SPC0
+
+static const port_pin_config_t adc_PinConfig = {
     /* Internal pull-up/down resistor is disabled */
     kPORT_PullDisable,
     /* Low internal pull resistor value is selected (not used since pull disabled) */
@@ -18,41 +42,120 @@ static const port_pin_config_t s_adcPinConfig = {
     /* Low drive strength is configured */
     kPORT_LowDriveStrength,
     /* Pin is configured as GPIO */
-	kPORT_MuxAlt2,
+	kPORT_MuxAlt0,
     /* Digital input enabled */
-    kPORT_InputBufferEnable,
+    kPORT_InputBufferDisable,
     /* Digital input is not inverted */
     kPORT_InputNormal,
     /* Pin Control Register fields [15:0] are not locked */
     kPORT_UnlockRegister
 };
 
-void BOARD_InitBootPins_ADC(void)
+void Init_ADC_Pins(void)
 {
-    BOARD_InitADC_Pins();
+
+    PORT_SetPinConfig(PORT0, ADC_TEMPERATURE_PIN, &adc_PinConfig);
+    PORT_SetPinConfig(PORT0, ADC_OUTPUT_SPEED_PIN, &adc_PinConfig);
+    PORT_SetPinConfig(PORT1, ADC_TRUBINE_SPEED_PIN, &adc_PinConfig);
+
+    vref_config_t vrefConfig;
+
+    /* 1) Configurar el reloj funcional de ADC0 */
+    CLOCK_SetClkDiv(kCLOCK_DivAdc0Clk, 1U);
+    CLOCK_AttachClk(kFRO_HF_to_ADC0);
+
+    /* 1) Configurar el reloj funcional de ADC1 */
+    CLOCK_SetClkDiv(kCLOCK_DivAdc1Clk, 1U);
+    CLOCK_AttachClk(kFRO_HF_to_ADC1);
+
+    /* enable VREF */
+    SPC_EnableActiveModeAnalogModules(DEMO_SPC_BASE, kSPC_controlVref);
+
+    VREF_GetDefaultConfig(&vrefConfig);
+    vrefConfig.bufferMode = kVREF_ModeBandgapOnly;
+    /* Initialize VREF module, the VREF module is only used to supply the bias current for LPADC. */
+    VREF_Init(DEMO_VREF_BASE, &vrefConfig);
+
+    lpadc_config_t              lpadcConfig;
+    lpadc_conv_command_config_t cmdConfig;
+    lpadc_conv_trigger_config_t trigConfig;
+
+    /* Config básica del LPADC */
+    LPADC_GetDefaultConfig(&lpadcConfig);
+    lpadcConfig.powerLevelMode = kLPADC_PowerLevelAlt4;
+	lpadcConfig.enableAnalogPreliminary = true;
+	lpadcConfig.referenceVoltageSource = 2U;
+
+	lpadcConfig.conversionAverageMode = kLPADC_ConversionAverage128;
+
+	LPADC_Init(TCM_LPADC0_BASE, &lpadcConfig);
+	LPADC_DoOffsetCalibration(TCM_LPADC0_BASE); /* Request offset calibration, automatic update OFSTRIM register. */
+	LPADC_DoAutoCalibration(TCM_LPADC0_BASE);
+
+	LPADC_Init(TCM_LPADC1_BASE, &lpadcConfig);
+	LPADC_DoOffsetCalibration(TCM_LPADC1_BASE); /* Request offset calibration, automatic update OFSTRIM register. */
+	LPADC_DoAutoCalibration(TCM_LPADC1_BASE);
+
+    /* OUTPUT_SPEED_SENSOR  (P0_14 = ADC0_B14 → canal 14, lado B) */
+    cmdConfig.channelNumber     = 14U;
+    cmdConfig.sampleChannelMode = kLPADC_SampleChannelSingleEndSideB;
+    LPADC_SetConvCommandConfig(TCM_LPADC0_BASE, TCM_LPADC_CMDID_OUTPUT, &cmdConfig);
+
+    /* ADC_TEMPERATURE_PIN  (P0_22 = ADC0_A14 → canal 14, lado A) */
+    cmdConfig.channelNumber     = 14U;
+    cmdConfig.sampleChannelMode = kLPADC_SampleChannelSingleEndSideA;
+    LPADC_SetConvCommandConfig(TCM_LPADC0_BASE, TCM_LPADC_CMDID_FLUID, &cmdConfig);
+
+    /* ADC_TRUBINE_SPEED_PIN  (P1_10 = ADC1_A10 → canal 10, lado A) */
+    cmdConfig.channelNumber     = 10U;
+    cmdConfig.sampleChannelMode = kLPADC_SampleChannelSingleEndSideA;
+    LPADC_SetConvCommandConfig(TCM_LPADC1_BASE, TCM_LPADC_CMDID_TURBINE, &cmdConfig);
+
+    /* Triggers de software para cada comando */
+    LPADC_GetDefaultConvTriggerConfig(&trigConfig);
+    trigConfig.targetCommandId = TCM_LPADC_CMDID_OUTPUT;
+    trigConfig.enableHardwareTrigger = false;  // puro software trigger
+
+//    /* Triggers de software para cada comando */
+//    LPADC_GetDefaultConvTriggerConfig(&trigConfig);
+//    trigConfig.targetCommandId = TCM_LPADC_CMDID_FLUID;
+//    trigConfig.enableHardwareTrigger = false;  // puro software trigger
+//
+//    /* Triggers de software para cada comando */
+//    LPADC_GetDefaultConvTriggerConfig(&trigConfig);
+//    trigConfig.targetCommandId = TCM_LPADC_CMDID_TURBINE;
+//    trigConfig.enableHardwareTrigger = false;  // puro software trigger
+
+    //trigConfig.targetCommandId = TCM_LPADC_CMDID_OUTPUT;
+    LPADC_SetConvTriggerConfig(TCM_LPADC0_BASE, TCM_LPADC_TRIG_OUTPUT, &trigConfig);
+//    LPADC_SetConvTriggerConfig(TCM_LPADC0_BASE, TCM_LPADC_TRIG_FLUID, &trigConfig);
+//    LPADC_SetConvTriggerConfig(TCM_LPADC1_BASE, TCM_LPADC_TRIG_TURBINE, &trigConfig);
+
+    lpadc_conv_result_t mLpadcResultConfigStruct;
 }
 
-void BOARD_InitADC_Pins(void)
+
+void TCM_Read_OutputSpeedSensorRaw(void)
 {
-    lpadc_config_t mLpadcConfigStruct;
-    lpadc_conv_trigger_config_t mLpadcTriggerConfigStruct;
-    lpadc_conv_command_config_t mLpadcCommandConfigStruct;
-    lpadc_conv_result_t mLpadcResultConfigStruct;
+//	lpadc_conv_result_t result;
+//	uint32_t triggerMask = (1UL << 0);
+//	const uint32_t g_LpadcResultShift = 3U;
+//
+//	LPADC_DoSoftwareTrigger(TCM_LPADC_BASE, triggerMask);
+//
+//	while (!LPADC_GetConvResult(TCM_LPADC_BASE, &result, 0U))
+//	{
+//	}
+//	Write_TCM_OutputSpeed_OSS( (result.convValue) >> g_LpadcResultShift  );
+}
 
-	LPADC_GetDefaultConfig(&mLpadcConfigStruct);
-	LPADC_Init(DEMO_LPADC_BASE, &mLpadcConfigStruct);
-	LPADC_DoOffsetCalibration(DEMO_LPADC_BASE); /* Request offset calibration, automatic update OFSTRIM register. */
-	LPADC_DoAutoCalibration(DEMO_LPADC_BASE);
-	LPADC_GetDefaultConvCommandConfig(&mLpadcCommandConfigStruct);
-	LPADC_GetDefaultConvTriggerConfig(&mLpadcTriggerConfigStruct);
-	LPADC_DoSoftwareTrigger(DEMO_LPADC_BASE, 1U); /* 1U is trigger0 mask. */
 
-    /* PORT1_8 (pin A1) is configured as FC4_P0 */
-    PORT_SetPinConfig(PORT0, ADC_TEMPERATURE_PIN, &s_adcPinConfig);
+void TCM_Read_FluidTempSensorRaw(void)
+{
+//	Write_TCM_FluidTemp_TFT( TCM_LPADC_ReadByTrigger(TCM_LPADC_TRIG_FLUID) );
+}
 
-    /* PORT1_9 (pin B1) is configured as FC4_P1 */
-    PORT_SetPinConfig(PORT0, ADC_OUTPUT_SPEED_PIN, &s_adcPinConfig);
-
-    /* PORT4_23 (pin U12) is configured as ADC0_A2 */
-    PORT_SetPinConfig(PORT0, ADC_TRUBINE_SPEED_PIN, &s_adcPinConfig);
+void TCM_Read_TurbineSpeedSensorRaw(void)
+{
+//	Write_TCM_TurbineSpeed_TSS (TCM_LPADC_ReadByTrigger(TCM_LPADC_TRIG_TURBINE) );
 }

--- a/BSW/IoHwAb/IoHwAb_adc.h
+++ b/BSW/IoHwAb/IoHwAb_adc.h
@@ -1,4 +1,5 @@
-
+#ifndef _IOHWAB_ADC_H_
+#define _IOHWAB_ADC_H_
 
 #include "fsl_common.h"
 #include "fsl_port.h"
@@ -7,10 +8,17 @@
 #include "fsl_debug_console.h"
 #include "board.h"
 #include "app.h"
+#include "clock_config.h"
+#include "fsl_vref.h"
+#include "fsl_spc.h"
 
 #define ADC_TEMPERATURE_PIN 	(22)
 #define ADC_OUTPUT_SPEED_PIN 	(14)
-#define ADC_TRUBINE_SPEED_PIN	(15)
+#define ADC_TRUBINE_SPEED_PIN	(10U)
 
-void BOARD_InitADC_Pins(void);
-void BOARD_InitBootPins_ADC(void);
+void Init_ADC_Pins(void);
+void TCM_Read_OutputSpeedSensorRaw(void);
+void TCM_Read_FluidTempSensorRaw(void);
+void TCM_Read_TurbineSpeedSensorRaw(void);
+
+#endif /* _IOHWAB_ADC_H_ */

--- a/BSW/IoHwAb/IoHwAb_gpio.c
+++ b/BSW/IoHwAb/IoHwAb_gpio.c
@@ -63,7 +63,28 @@ static const port_pin_config_t s_gpioPinConfig = {
     kPORT_UnlockRegister
 };
 
-
+static const port_pin_config_t s_BrakePedal_PinConfig = {
+    /* Internal pull-up/down resistor is disabled */
+	kPORT_PullDown,
+    /* Low internal pull resistor value is selected (not used since pull disabled) */
+    kPORT_LowPullResistor,
+    /* Fast slew rate is configured */
+    kPORT_FastSlewRate,
+    /* Passive input filter is disabled */
+    kPORT_PassiveFilterDisable,
+    /* Open drain output is disabled */
+    kPORT_OpenDrainDisable,
+    /* Low drive strength is configured */
+    kPORT_LowDriveStrength,
+    /* Pin is configured as GPIO */
+	kPORT_MuxAsGpio,
+    /* Digital input enabled */
+    kPORT_InputBufferEnable,
+    /* Digital input is not inverted */
+    kPORT_InputNormal,
+    /* Pin Control Register fields [15:0] are not locked */
+    kPORT_UnlockRegister
+};
 
 /* **********************************************************************
  * Functions
@@ -82,14 +103,14 @@ void Init_Pin_BreakPedal (void)
 {
     /*PIN BREAK PEDAL*/
 
-	/* PORT1_PIN8 is configured as PIO0_10 */
-    PORT_SetPinConfig(PORT1, BREAK_PEDAL_PIN, &s_gpioPinConfig);
+	/* PORT3_PIN4 is configured as input */
+    PORT_SetPinConfig(PORT3, BREAK_PEDAL_PIN, &s_BrakePedal_PinConfig);
 
     gpio_pin_config_t Pin_BreakPedal_config = {
     	kGPIO_DigitalInput,
 		GPIO_LOGIC_LEVEL_LOW,
     };
-    GPIO_PinInit(GPIO1, BREAK_PEDAL_PIN, &Pin_BreakPedal_config);
+    GPIO_PinInit(GPIO3, BREAK_PEDAL_PIN, &Pin_BreakPedal_config);
 }
 
 /**
@@ -110,8 +131,8 @@ void Init_Pin_GearPossition(void)
     /* --- PORT mux configuration for gear position pins --- */
     PORT_SetPinConfig(PORT1, PARKING_PIN, &s_gpioPinConfig);
     PORT_SetPinConfig(PORT1, REVERSE_PIN, &s_gpioPinConfig);
-    PORT_SetPinConfig(PORT1, NEUTRAL_PIN, &s_gpioPinConfig);
-    PORT_SetPinConfig(PORT1, DRIVE_PIN, &s_gpioPinConfig);
+    PORT_SetPinConfig(PORT3, NEUTRAL_PIN, &s_gpioPinConfig);
+    PORT_SetPinConfig(PORT2, DRIVE_PIN, &s_gpioPinConfig);
     PORT_SetPinConfig(PORT1, FIRST_PIN, &s_gpioPinConfig);
     PORT_SetPinConfig(PORT1, SECOND_PIN, &s_gpioPinConfig);
 
@@ -133,16 +154,16 @@ void Init_Pin_GearPossition(void)
         kGPIO_DigitalInput,
         GPIO_LOGIC_LEVEL_LOW,
     };
-    GPIO_PinInit(GPIO1, NEUTRAL_PIN, &neutralConfig);
+    GPIO_PinInit(GPIO3, NEUTRAL_PIN, &neutralConfig);
 
     gpio_pin_config_t driveConfig = {
         kGPIO_DigitalInput,
         GPIO_LOGIC_LEVEL_LOW,
     };
-    GPIO_PinInit(GPIO1, DRIVE_PIN, &driveConfig);
+    GPIO_PinInit(GPIO2, DRIVE_PIN, &driveConfig);
 
     gpio_pin_config_t firstConfig = {
-        kGPIO_DigitalInput,
+       kGPIO_DigitalInput,
         GPIO_LOGIC_LEVEL_LOW,
     };
     GPIO_PinInit(GPIO1, FIRST_PIN, &firstConfig);
@@ -173,7 +194,7 @@ void Init_Pin_ShiftSolenoids(void)
     PORT_SetPinConfig(PORT1, SOLENOID_A_PIN, &s_gpioPinConfig);
     PORT_SetPinConfig(PORT1, SOLENOID_B_PIN, &s_gpioPinConfig);
     PORT_SetPinConfig(PORT1, SOLENOID_C_PIN, &s_gpioPinConfig);
-    PORT_SetPinConfig(PORT2, SOLENOID_D_PIN, &s_gpioPinConfig);
+    PORT_SetPinConfig(PORT1, SOLENOID_D_PIN, &s_gpioPinConfig);
     PORT_SetPinConfig(PORT4, SOLENOID_E_PIN, &s_gpioPinConfig);
 
     /* --- GPIO configuration as digital outputs --- */
@@ -200,7 +221,7 @@ void Init_Pin_ShiftSolenoids(void)
         kGPIO_DigitalOutput,
         GPIO_LOGIC_LEVEL_LOW,
     };
-    GPIO_PinInit(GPIO2, SOLENOID_D_PIN, &solenoidDConfig);
+    GPIO_PinInit(GPIO1, SOLENOID_D_PIN, &solenoidDConfig);
 
     gpio_pin_config_t solenoidEConfig = {
         kGPIO_DigitalOutput,

--- a/BSW/IoHwAb/IoHwAb_gpio.h
+++ b/BSW/IoHwAb/IoHwAb_gpio.h
@@ -18,8 +18,8 @@
  * instance specified in app.h or board.h.
  */
 
-#ifndef _IOWHAB_GPIO_H_
-#define _IOWHAB_GPIO_H_
+#ifndef _IOHWAB_GPIO_H_
+#define _IOHWAB_GPIO_H_
 
 
 /* **********************************************************************
@@ -42,7 +42,7 @@
  * @name Brake Pedal Input
  * @{
  */
-#define BREAK_PEDAL_PIN	8U			/**< Brake pedal GPIO pin */
+#define BREAK_PEDAL_PIN	4U			/**< Brake pedal GPIO pin */
 /** @} */
 
 
@@ -52,10 +52,10 @@
  */
 #define PARKING_PIN		(9U)			/**< Gear position: Parking  */
 #define REVERSE_PIN 	(12U)			/**< Gear position: Reverse  */
-#define NEUTRAL_PIN		(13U)			/**< Gear position: Neutral  */
-#define DRIVE_PIN		(14U)			/**< Gear position: Drive    */
-#define FIRST_PIN		(15U)			/**< Gear position: 1st gear */
-#define SECOND_PIN		(16U)			/**< Gear position: 2nd gear */
+#define NEUTRAL_PIN		(5U)			/**< Gear position: Neutral  */
+#define DRIVE_PIN		(0U)			/**< Gear position: Drive    */
+#define FIRST_PIN		(23U)			/**< Gear position: 1st gear */
+#define SECOND_PIN		(13U)			/**< Gear position: 2nd gear */
 /** @} */
 
 /**
@@ -64,8 +64,8 @@
  */
 #define SOLENOID_A_PIN      (17U)  	/**< Solenoid A */
 #define SOLENOID_B_PIN      (22U)  	/**< Solenoid B */
-#define SOLENOID_C_PIN      (23U)  	/**< Solenoid C */
-#define SOLENOID_D_PIN      (0U)   	/**< Solenoid D */
+#define SOLENOID_C_PIN      (15U)  	/**< Solenoid C */
+#define SOLENOID_D_PIN      (14U)   	/**< Solenoid D */
 #define SOLENOID_E_PIN      (4U)  	/**< Solenoid E */
 /** @} */
 
@@ -102,4 +102,4 @@ void Init_Pin_ShiftSolenoids(void);
 void Init_Pin_ShiftLockSolenoid(void);
 
 
-#endif /* _IOWHAB_GPIO_H_ */
+#endif /* _IOHWAB_GPIO_H_ */

--- a/BSW/IoHwAb/IoHwAb_pwm.c
+++ b/BSW/IoHwAb/IoHwAb_pwm.c
@@ -4,4 +4,149 @@
  */
 
 #include "IoHwAb_pwm.h"
+#include "fsl_common.h"
+#include "fsl_port.h"
+#include "pin_mux.h"
+#include "fsl_pwm.h"
 
+
+
+
+static const port_pin_config_t s_pwmPinConfig = {
+    /* Internal pull-up/down resistor is disabled */
+    kPORT_PullDisable,
+    /* Low internal pull resistor value is selected (not used since pull disabled) */
+    kPORT_LowPullResistor,
+    /* Fast slew rate is configured */
+    kPORT_FastSlewRate,
+    /* Passive input filter is disabled */
+    kPORT_PassiveFilterDisable,
+    /* Open drain output is disabled */
+    kPORT_OpenDrainDisable,
+    /* Low drive strength is configured */
+    kPORT_LowDriveStrength,
+    /* Pin is configured as GPIO */
+	kPORT_MuxAlt5,
+    /* Digital input enabled */
+    kPORT_InputBufferDisable,
+    /* Digital input is not inverted */
+    kPORT_InputNormal,
+    /* Pin Control Register fields [15:0] are not locked */
+    kPORT_UnlockRegister
+};
+
+static void PWM_DRV_Init3PhPwm(void)
+{
+    uint16_t deadTimeVal;
+    pwm_signal_param_t pwmSignal[2];
+    uint32_t pwmSourceClockInHz;
+    uint32_t pwmFrequencyInHz = APP_DEFAULT_PWM_FREQUENCY;
+
+    pwmSourceClockInHz = PWM_SRC_CLK_FREQ;
+
+    /* Set deadtime count, we set this to about 650ns */
+    deadTimeVal = ((uint64_t)pwmSourceClockInHz * 650) / 1000000000;
+
+    pwmSignal[0].pwmChannel       = kPWM_PwmA;
+    pwmSignal[0].level            = kPWM_HighTrue;
+    pwmSignal[0].dutyCyclePercent = 80; /* 1 percent dutycycle */
+    pwmSignal[0].deadtimeValue    = deadTimeVal;
+    pwmSignal[0].faultState       = kPWM_PwmFaultState0;
+    pwmSignal[0].pwmchannelenable = true;
+
+    pwmSignal[1].pwmChannel = kPWM_PwmB;
+    pwmSignal[1].level      = kPWM_HighTrue;
+    /* Dutycycle field of PWM B does not matter as we are running in PWM A complementary mode */
+    pwmSignal[1].dutyCyclePercent = 80;
+    pwmSignal[1].deadtimeValue    = deadTimeVal;
+    pwmSignal[1].faultState       = kPWM_PwmFaultState0;
+    pwmSignal[1].pwmchannelenable = true;
+
+    /*********** PWMA_SM0 - phase A, configuration, setup 2 channel as an example ************/
+    PWM_SetupPwm(BOARD_PWM_BASEADDR, kPWM_Module_0, pwmSignal, 2, kPWM_SignedCenterAligned, pwmFrequencyInHz,
+                 pwmSourceClockInHz);
+
+    PWM_SetupPwm(BOARD_PWM_BASEADDR, kPWM_Module_1, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
+                 pwmSourceClockInHz);
+
+    PWM_SetupPwm(BOARD_PWM_BASEADDR, kPWM_Module_2, pwmSignal, 1, kPWM_SignedCenterAligned, pwmFrequencyInHz,
+                 pwmSourceClockInHz);
+}
+
+void Init_Pin_PWM(void)
+{
+	PORT_SetPinConfig(PORT2, LINE_PRESSURE_PIN, &s_pwmPinConfig);
+	PORT_SetPinConfig(PORT2, TCC_CONTROL_PIN, &s_pwmPinConfig);
+
+    /* Structure of initialize PWM */
+    pwm_config_t pwmConfig;
+    pwm_fault_param_t faultConfig;
+    uint32_t pwmVal = 4;
+
+    PWM_GetDefaultConfig(&pwmConfig);
+
+    /* Use full cycle reload */
+    pwmConfig.reloadLogic = kPWM_ReloadPwmFullCycle;
+    /* PWM A & PWM B form a complementary PWM pair */
+    pwmConfig.pairOperation   = kPWM_Independent;
+    pwmConfig.enableDebugMode = true;
+
+	/* Initialize submodule 0 */
+    if (PWM_Init(BOARD_PWM_BASEADDR, kPWM_Module_0, &pwmConfig) == kStatus_Fail)
+    {
+    	PRINTF("PWM initialization failed\n");
+
+    }
+
+    /* Initialize submodule 1, make it use same counter clock as submodule 0. */
+    pwmConfig.clockSource           = kPWM_Submodule0Clock;
+    pwmConfig.prescale              = kPWM_Prescale_Divide_1;
+    pwmConfig.initializationControl = kPWM_Initialize_MasterSync;
+    if (PWM_Init(BOARD_PWM_BASEADDR, kPWM_Module_1, &pwmConfig) == kStatus_Fail)
+    {
+    	PRINTF("PWM initialization failed\n");
+    }
+
+    /* Initialize submodule 2 the same way as submodule 1 */
+    if (PWM_Init(BOARD_PWM_BASEADDR, kPWM_Module_2, &pwmConfig) == kStatus_Fail)
+    {
+	   PRINTF("PWM initialization failed\n");
+    }
+
+    /*
+     *   config->faultClearingMode = kPWM_Automatic;
+     *   config->faultLevel = false;
+     *   config->enableCombinationalPath = true;
+     *   config->recoverMode = kPWM_NoRecovery;
+     */
+    PWM_FaultDefaultConfig(&faultConfig);
+
+
+    faultConfig.faultLevel = DEMO_PWM_FAULT_LEVEL;
+
+    /* Sets up the PWM fault protection */
+    PWM_SetupFaults(BOARD_PWM_BASEADDR, kPWM_Fault_0, &faultConfig);
+    PWM_SetupFaults(BOARD_PWM_BASEADDR, kPWM_Fault_1, &faultConfig);
+    PWM_SetupFaults(BOARD_PWM_BASEADDR, kPWM_Fault_2, &faultConfig);
+    PWM_SetupFaults(BOARD_PWM_BASEADDR, kPWM_Fault_3, &faultConfig);
+
+    /* Set PWM fault disable mapping for submodule 0/1/2 */
+    PWM_SetupFaultDisableMap(BOARD_PWM_BASEADDR, kPWM_Module_0, kPWM_PwmA, kPWM_faultchannel_0,
+							DEMO_PWM_DISABLE_MAP_OP(kPWM_FaultDisable_0 | kPWM_FaultDisable_1 | kPWM_FaultDisable_2 | kPWM_FaultDisable_3));
+    PWM_SetupFaultDisableMap(BOARD_PWM_BASEADDR, kPWM_Module_1, kPWM_PwmA, kPWM_faultchannel_0,
+							DEMO_PWM_DISABLE_MAP_OP(kPWM_FaultDisable_0 | kPWM_FaultDisable_1 | kPWM_FaultDisable_2 | kPWM_FaultDisable_3));
+    PWM_SetupFaultDisableMap(BOARD_PWM_BASEADDR, kPWM_Module_2, kPWM_PwmA, kPWM_faultchannel_0,
+							DEMO_PWM_DISABLE_MAP_OP(kPWM_FaultDisable_0 | kPWM_FaultDisable_1 | kPWM_FaultDisable_2 | kPWM_FaultDisable_3));
+    /*
+     * Call the init function with demo configuration.
+     * Recommend to invoke API PWM_SetupPwm after PWM and fault configuration, because reference manual advises to
+     * set OUTEN register after other PWM configurations. But set OUTEN register before MCTRL register is okay.
+     */
+    PWM_DRV_Init3PhPwm();
+
+    /* Set the load okay bit for all submodules to load registers from their buffer */
+    PWM_SetPwmLdok(BOARD_PWM_BASEADDR, kPWM_Control_Module_0 | kPWM_Control_Module_1 | kPWM_Control_Module_2, true);
+
+    /* Start the PWM generation from Submodules 0, 1 and 2 */
+    PWM_StartTimer(BOARD_PWM_BASEADDR, kPWM_Control_Module_0 | kPWM_Control_Module_1 | kPWM_Control_Module_2);
+}

--- a/BSW/IoHwAb/IoHwAb_pwm.h
+++ b/BSW/IoHwAb/IoHwAb_pwm.h
@@ -1,4 +1,23 @@
+#ifndef _IOHWAB_PWM_H_
+#define _IOHWAB_PWM_H_
+
 #include "fsl_debug_console.h"
 #include "board.h"
 #include "app.h"
 #include "fsl_pwm.h"
+
+
+#define LINE_PRESSURE_PIN	(6U)
+#define TCC_CONTROL_PIN		(7U)
+
+#define BOARD_PWM_BASEADDR        PWM1
+#define PWM_SRC_CLK_FREQ          CLOCK_GetFreq(kCLOCK_BusClk)
+#define DEMO_PWM_FAULT_LEVEL      true
+#define APP_DEFAULT_PWM_FREQUENCY (10000UL)
+#define DEMO_PWM_DISABLE_MAP_OP
+
+static void PWM_DRV_Init3PhPwm(void);
+void Init_Pin_PWM(void);
+
+
+#endif /* _IOHWAB_PWM_H_ */

--- a/board/app.h
+++ b/board/app.h
@@ -17,6 +17,7 @@
 #define DEMO_SPC_BASE           SPC0
 #define DEMO_LPADC_BASE         ADC0
 #define DEMO_LPADC_USER_CHANNEL 2U
+
 /*${macro:end}*/
 
 /*******************************************************************************

--- a/drivers/fsl_vref.c
+++ b/drivers/fsl_vref.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2019-2022, 2024 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fsl_vref.h"
+
+/* Component ID definition, used by tools. */
+#ifndef FSL_COMPONENT_ID
+#define FSL_COMPONENT_ID "platform.drivers.vref_1"
+#endif
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*!
+ * @brief Gets the instance from the base address
+ *
+ * @param base VREF peripheral base address
+ *
+ * @return The VREF instance
+ */
+static uint32_t VREF_GetInstance(VREF_Type *base);
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+/*! @brief Pointers to VREF bases for each instance. */
+static VREF_Type *const s_vrefBases[] = VREF_BASE_PTRS;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+/*! @brief Pointers to VREF clocks for each instance. */
+static const clock_ip_name_t s_vrefClocks[] = VREF_CLOCKS;
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+static uint32_t VREF_GetInstance(VREF_Type *base)
+{
+    uint32_t instance;
+
+    /* Find the instance index from base address mappings. */
+    /*
+     * $Branch Coverage Justification$
+     * (instance >= ARRAY_SIZE(s_vrefBases)) not covered. The peripheral base
+     * address is always valid and checked by assert.
+     */
+    for (instance = 0; instance < ARRAY_SIZE(s_vrefBases); instance++)
+    {
+        /*
+         * $Branch Coverage Justification$
+         * (s_vrefBases[instance] != base) not covered. The peripheral base
+         * address is always valid and checked by assert.
+         */
+        if (MSDK_REG_SECURE_ADDR(s_vrefBases[instance]) == MSDK_REG_SECURE_ADDR(base))
+        {
+            break;
+        }
+    }
+
+    assert(instance < ARRAY_SIZE(s_vrefBases));
+
+    return instance;
+}
+
+/*!
+ * brief Enables the clock gate and configures the VREF module according to the configuration structure.
+ *
+ * This function must be called before calling all other VREF driver functions, read/write registers, and
+ * configurations with user-defined settings. The example below shows how to set up vref_config_t parameters
+ * and how to call the VREF_Init function by passing in these parameters.
+ * code
+ *    vref_config_t vrefConfig;
+ *    VREF_GetDefaultConfig(VREF, &vrefConfig);
+ *    vrefConfig.bufferMode = kVREF_ModeHighPowerBuffer;
+ *    VREF_Init(VREF, &vrefConfig);
+ * endcode
+ *
+ * param base VREF peripheral address.
+ * param config Pointer to the configuration structure.
+ */
+void VREF_Init(VREF_Type *base, const vref_config_t *config)
+{
+    assert(config != NULL);
+
+    uint32_t tmp32 = 0UL;
+
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Ungate clock for VREF */
+    CLOCK_EnableClock(s_vrefClocks[VREF_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+
+    base->CSR |= VREF_CSR_LPBGEN_MASK;
+    /* After enabling low power bandgap, delay 20 us. */
+    SDK_DelayAtLeastUs(20U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+
+#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0U))
+    /* Provides bias current for other peripherals. */
+    if (config->enableLowPowerBuff)
+    {
+        base->CSR |= VREF_CSR_LPBG_BUF_EN_MASK;
+    }
+#endif /* FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER */
+
+    if (config->bufferMode != kVREF_ModeBandgapOnly)
+    {
+        if (config->enableHCBandgap)
+        {
+            tmp32 |= VREF_CSR_HCBGEN_MASK;
+        }
+
+        if (config->enableInternalVoltageRegulator)
+        {
+            tmp32 |= VREF_CSR_REGEN_MASK;
+        }
+
+        if (config->enableChopOscillator)
+        {
+            tmp32 |= (VREF_CSR_REGEN_MASK | VREF_CSR_CHOPEN_MASK);
+        }
+
+        if (config->enableCurvatureCompensation)
+        {
+            tmp32 |= VREF_CSR_ICOMPEN_MASK;
+        }
+
+        if (config->bufferMode == kVREF_ModeLowPowerBuffer)
+        {
+            tmp32 |= VREF_CSR_BUF21EN_MASK;
+        }
+        else
+        {
+            tmp32 |= (VREF_CSR_BUF21EN_MASK | VREF_CSR_HI_PWR_LV_MASK);
+        }
+
+        base->CSR |= tmp32;
+        /* After enabling high accurancy bandgap, delay 400 us. */
+        SDK_DelayAtLeastUs(400U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+    }
+}
+
+/*!
+ * brief Stops and disables the clock for the VREF module.
+ *
+ * This function should be called to shut down the module.
+ * This is an example.
+ * code
+ *    vref_config_t vrefUserConfig;
+ *    VREF_GetDefaultConfig(VREF, &vrefUserConfig);
+ *    VREF_Init(VREF, &vrefUserConfig);
+ *    ...
+ *    VREF_Deinit(VREF);
+ * endcode
+ *
+ * param base VREF peripheral address.
+ */
+void VREF_Deinit(VREF_Type *base)
+{
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Gate clock for VREF */
+    CLOCK_DisableClock(s_vrefClocks[VREF_GetInstance(base)]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
+}
+
+/*!
+ * brief Initializes the VREF configuration structure.
+ *
+ * This function initializes the VREF configuration structure to default values.
+ * This is an example.
+ * code
+ *    config->bufferMode = kVREF_ModeHighPowerBuffer;
+ *    config->enableInternalVoltageRegulator = true;
+ *    config->enableChopOscillator           = true;
+ *    config->enableHCBandgap                = true;
+ *    config->enableCurvatureCompensation    = true;
+ *    config->enableLowPowerBuff             = true;
+ * endcode
+ *
+ * param config Pointer to the initialization structure.
+ */
+void VREF_GetDefaultConfig(vref_config_t *config)
+{
+    assert(NULL != config);
+
+    /* Initializes the configure structure to zero. */
+    (void)memset(config, 0, sizeof(*config));
+
+    config->bufferMode                     = kVREF_ModeHighPowerBuffer;
+    config->enableInternalVoltageRegulator = true;
+    config->enableChopOscillator           = true;
+    config->enableHCBandgap                = true;
+    config->enableCurvatureCompensation    = true;
+#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0U))
+    config->enableLowPowerBuff             = true;
+#endif /* FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER */
+}
+
+/*!
+ * brief Sets a TRIM value for the accurate 1.0V bandgap output.
+ *
+ * This function sets a TRIM value for the reference voltage. It will trim the accurate 1.0V bandgap by 0.5mV each step.
+ *
+ * param base VREF peripheral address.
+ * param trimValue Value of the trim register to set the output reference voltage (maximum 0x3F (6-bit)).
+ */
+void VREF_SetVrefTrimVal(VREF_Type *base, uint8_t trimValue)
+{
+    uint32_t tmp32 = base->UTRIM;
+
+    tmp32 &= (~VREF_UTRIM_VREFTRIM_MASK);
+    tmp32 |= VREF_UTRIM_VREFTRIM(trimValue);
+
+    base->UTRIM = tmp32;
+
+    if (VREF_CSR_CHOPEN_MASK == (base->CSR & VREF_CSR_CHOPEN_MASK))
+    {
+        /* After enabling high accurancy bandgap, delay 400 us. */
+        SDK_DelayAtLeastUs(400U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+    }
+    else
+    {
+        /*Wait internal HC voltage reference stable*/
+        /*
+         * $Branch Coverage Justification$
+         * while ((base->CSR & VREF_CSR_VREFST_MASK) != 0U) not covered. Test unfeasible,
+         * the internal HC voltage stable state is too short not to catch.
+         */
+        while ((base->CSR & VREF_CSR_VREFST_MASK) == 0U)
+        {
+        }
+    }
+}
+
+#if !(defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0U))
+/*!
+ * brief Sets a TRIM value for the accurate buffered VREF output.
+ *
+ * This function sets a TRIM value for the reference voltage. If buffer mode be set to other values (Buf21
+ * enabled), it will trim the VREF_OUT by 0.1V each step from 1.0V to 2.1V.
+ *
+ * note When Buf21 is enabled, the value of UTRIM[TRIM2V1] should be ranged from 0b0000 to 0b1011 in order to trim the
+ * output voltage from 1.0V to 2.1V, other values will make the VREF_OUT to default value, 1.0V.
+ *
+ * param base VREF peripheral address.
+ * param trim21Value Value of the trim register to set the output reference voltage (maximum 0xF (4-bit)).
+ */
+void VREF_SetTrim21Val(VREF_Type *base, uint8_t trim21Value)
+{
+    uint32_t tmp32 = base->UTRIM;
+
+    tmp32 &= (~VREF_UTRIM_TRIM2V1_MASK);
+    tmp32 |= VREF_UTRIM_TRIM2V1(trim21Value);
+
+    base->UTRIM = tmp32;
+
+    if (VREF_CSR_CHOPEN_MASK == (base->CSR & VREF_CSR_CHOPEN_MASK))
+    {
+        /* After enabling high accurancy bandgap, delay 400 us. */
+        SDK_DelayAtLeastUs(400U, SDK_DEVICE_MAXIMUM_CPU_CLOCK_FREQUENCY);
+    }
+    else
+    {
+        /*Wait internal HC voltage reference stable*/
+        /*
+         * $Branch Coverage Justification$
+         * while ((base->CSR & VREF_CSR_VREFST_MASK) != 0U) not covered. Test unfeasible,
+         * the internal HC voltage stable state is too short not to catch.
+         */
+        while ((base->CSR & VREF_CSR_VREFST_MASK) == 0U)
+        {
+        }
+    }
+}
+#endif /* FSL_FEATURE_VREF_HAS_TRIM2V1 */
+
+/*!
+ * brief Reads the VREF trim value.
+ *
+ * This function gets the TRIM value from the UTRIM register. It reads UTRIM[VREFTRIM] (13:8)
+ *
+ * param base VREF peripheral address.
+ * return 6-bit value of trim setting.
+ */
+uint8_t VREF_GetVrefTrimVal(VREF_Type *base)
+{
+    uint8_t trimValue;
+
+    trimValue = (uint8_t)((base->UTRIM & VREF_UTRIM_VREFTRIM_MASK) >> VREF_UTRIM_VREFTRIM_SHIFT);
+
+    return trimValue;
+}
+
+#if !(defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0U))
+/*!
+ * brief Reads the VREF 2.1V trim value.
+ *
+ * This function gets the TRIM value from the UTRIM register. It reads UTRIM[TRIM2V1] (3:0),
+ *
+ * param base VREF peripheral address.
+ * return 4-bit value of trim setting.
+ */
+uint8_t VREF_GetTrim21Val(VREF_Type *base)
+{
+    uint8_t trimValue;
+
+    trimValue = (uint8_t)((base->UTRIM & VREF_UTRIM_TRIM2V1_MASK) >> VREF_UTRIM_TRIM2V1_SHIFT);
+
+    return trimValue;
+}
+#endif /* FSL_FEATURE_VREF_HAS_TRIM2V1 */

--- a/drivers/fsl_vref.h
+++ b/drivers/fsl_vref.h
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2019-2024 NXP
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FSL_VREF_H_
+#define FSL_VREF_H_
+
+#include "fsl_common.h"
+
+/*!
+ * @addtogroup vref
+ * @{
+ */
+
+/******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @name Driver version */
+/*! @{ */
+#define FSL_VREF_DRIVER_VERSION (MAKE_VERSION(2, 4, 0)) /*!< Version 2.4.0. */
+/*! @} */
+
+/*! @brief VREF buffer modes. */
+typedef enum _vref_buffer_mode
+{
+    kVREF_ModeBandgapOnly     = 0U, /*!< Bandgap enabled/standby. */
+    kVREF_ModeLowPowerBuffer  = 1U, /*!< Low-power buffer mode enabled */
+    kVREF_ModeHighPowerBuffer = 2U, /*!< High-power buffer mode enabled */
+} vref_buffer_mode_t;
+
+/*! @brief The description structure for the VREF module. */
+typedef struct _vref_config
+{
+    vref_buffer_mode_t bufferMode;       /*!< Buffer mode selection */
+    bool enableInternalVoltageRegulator; /*!< Provide additional supply noise rejection. */
+    bool enableChopOscillator;           /*!< Enable Chop oscillator.*/
+    bool enableHCBandgap;                /*!< Enable High-Accurate bandgap.*/
+    bool enableCurvatureCompensation;    /*!< Enable second order curvature compensation. */
+#if !(defined(FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER) && (FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER == 0U))
+    bool enableLowPowerBuff;             /*!< Provides bias current for other peripherals.*/
+#endif /* FSL_FEATURE_VREF_HAS_LOWPOWER_BUFFER */
+
+} vref_config_t;
+
+/******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/*!
+ * @name Initialization and deinitialization
+ * @{
+ */
+
+/*!
+ * @brief Enables the clock gate and configures the VREF module according to the configuration structure.
+ *
+ * This function must be called before calling all other VREF driver functions, read/write registers, and
+ * configurations with user-defined settings. The example below shows how to set up vref_config_t parameters
+ * and how to call the VREF_Init function by passing in these parameters.
+ * @code
+ *    vref_config_t vrefConfig;
+ *    VREF_GetDefaultConfig(VREF, &vrefConfig);
+ *    vrefConfig.bufferMode = kVREF_ModeHighPowerBuffer;
+ *    VREF_Init(VREF, &vrefConfig);
+ * @endcode
+ *
+ * @param base VREF peripheral address.
+ * @param config Pointer to the configuration structure.
+ */
+void VREF_Init(VREF_Type *base, const vref_config_t *config);
+
+/*!
+ * @brief Stops and disables the clock for the VREF module.
+ *
+ * This function should be called to shut down the module.
+ * This is an example.
+ * @code
+ *    vref_config_t vrefUserConfig;
+ *    VREF_GetDefaultConfig(VREF, &vrefUserConfig);
+ *    VREF_Init(VREF, &vrefUserConfig);
+ *    ...
+ *    VREF_Deinit(VREF);
+ * @endcode
+ *
+ * @param base VREF peripheral address.
+ */
+void VREF_Deinit(VREF_Type *base);
+
+/*!
+ * @brief Initializes the VREF configuration structure.
+ *
+ * This function initializes the VREF configuration structure to default values.
+ * This is an example.
+ * @code
+ *    config->bufferMode = kVREF_ModeHighPowerBuffer;
+ *    config->enableInternalVoltageRegulator = true;
+ *    config->enableChopOscillator           = true;
+ *    config->enableHCBandgap                = true;
+ *    config->enableCurvatureCompensation    = true;
+ *    config->enableLowPowerBuff             = true;
+ * @endcode
+ *
+ * @param config Pointer to the initialization structure.
+ */
+void VREF_GetDefaultConfig(vref_config_t *config);
+
+/*! @} */
+
+/*!
+ * @name Trim functions
+ * @{
+ */
+
+/*!
+ * @brief Sets a TRIM value for the accurate 1.0V bandgap output.
+ *
+ * This function sets a TRIM value for the reference voltage. It will trim the accurate 1.0V bandgap by 0.5mV each step.
+ *
+ * @param base VREF peripheral address.
+ * @param trimValue Value of the trim register to set the output reference voltage (maximum 0x3F (6-bit)).
+ */
+void VREF_SetVrefTrimVal(VREF_Type *base, uint8_t trimValue);
+
+#if !(defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0U))
+/*!
+ * @brief Sets a TRIM value for the accurate buffered VREF output.
+ *
+ * This function sets a TRIM value for the reference voltage. If buffer mode be set to other values (Buf21
+ * enabled), it will trim the VREF_OUT by 0.1V each step from 1.0V to 2.1V.
+ *
+ * @note When Buf21 is enabled, the value of UTRIM[TRIM2V1] should be ranged from 0b0000 to 0b1011 in order to trim the
+ * output voltage from 1.0V to 2.1V, other values will make the VREF_OUT to default value, 1.0V.
+ *
+ * @param base VREF peripheral address.
+ * @param trim21Value Value of the trim register to set the output reference voltage (maximum 0xF (4-bit)).
+ */
+void VREF_SetTrim21Val(VREF_Type *base, uint8_t trim21Value);
+#endif /* FSL_FEATURE_VREF_HAS_TRIM2V1 */
+
+/*!
+ * @brief Reads the trim value.
+ *
+ * This function gets the TRIM value from the UTRIM register. It reads UTRIM[VREFTRIM] (13:8)
+ *
+ * @param base VREF peripheral address.
+ * @return 6-bit value of trim setting.
+ */
+uint8_t VREF_GetVrefTrimVal(VREF_Type *base);
+
+#if !(defined(FSL_FEATURE_VREF_HAS_TRIM2V1) && (FSL_FEATURE_VREF_HAS_TRIM2V1 == 0U))
+/*!
+ * @brief Reads the VREF 2.1V trim value.
+ *
+ * This function gets the TRIM value from the UTRIM register. It reads UTRIM[TRIM2V1] (3:0),
+ *
+ * @param base VREF peripheral address.
+ * @return 4-bit value of trim setting.
+ */
+uint8_t VREF_GetTrim21Val(VREF_Type *base);
+#endif /* FSL_FEATURE_VREF_HAS_TRIM2V1 */
+
+#if (defined(FSL_FEATURE_VREF_HAS_TEST_UNLOCK_REG) && (FSL_FEATURE_VREF_HAS_TEST_UNLOCK_REG == 1U))
+/*!
+ * @brief Set VREF test unlock value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF test unlock value.
+ */
+static inline void VREF_SetTestUlockValue(VREF_Type *base, uint16_t value)
+{
+    base->TEST_UNLOCK |= VREF_TEST_UNLOCK_TEST_UNLOCK(value);
+}
+
+/*!
+ * @brief Get VREF test unlock value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF test unlock value.
+ */
+static inline uint16_t VREF_GetTestUlockValue(VREF_Type *base)
+{
+    return (uint16_t)(base->TEST_UNLOCK & VREF_TEST_UNLOCK_TEST_UNLOCK_VALUE_MASK >> VREF_TEST_UNLOCK_TEST_UNLOCK_VALUE_SHIFT);
+}
+
+/*!
+ * @brief Decides whether to enable/disable VREF test unlock.
+ *
+ * @param base VREF peripheral address.
+ * @param enable VREF test unlock enable/disable.
+ * - \b true  VREF test unlock enable.
+ * - \b false VREF test unlock disable.
+ */
+static inline void VREF_SetTestUlockEnable(VREF_Type *base, bool enable)
+{
+    if (enable)
+    {
+        base->TEST_UNLOCK |= VREF_TEST_UNLOCK_TEST_UNLOCK_MASK;
+    }
+    else
+    {
+        base->TEST_UNLOCK &= ~VREF_TEST_UNLOCK_TEST_UNLOCK_MASK;
+    }
+}
+#endif /* FSL_FEATURE_VREF_HAS_TEST_UNLOCK_REG */
+
+#if (defined(FSL_FEATURE_VREF_HAS_TRIM0_REG) && (FSL_FEATURE_VREF_HAS_TRIM0_REG == 1U))
+/*!
+ * @brief Decides whether to reverse VREF amplifier polarity.
+ *
+ * @param base VREF peripheral address.
+ * @param reverse VREF amplifier polarity reverse enable/disable.
+ * - \b true  VREF amplifier polarity reverse enable.
+ * - \b false VREF amplifier polarity reverse disable.
+ */
+static inline void VREF_SetAmpPolValue(VREF_Type *base, uint16_t reverse)
+{
+    if (reverse)
+    {
+        base->TRIM0 |= VREF_TRIM0_FLIP_MASK;
+    }
+    else
+    {
+        base->TRIM0 &= ~VREF_TRIM0_FLIP_MASK;
+    }
+}
+
+/*!
+ * @brief Set VREF P7 trim value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF P7 trim value.
+ */
+static inline void VREF_SetP7TrimValue(VREF_Type *base, uint8_t value)
+{
+    base->TRIM0 = (base->TRIM0 & ~VREF_TRIM0_P7_TRIM_MASK) | VREF_TRIM0_P7_TRIM(value);
+}
+
+/*!
+ * @brief Get VREF P7 trim value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF P7 trim value.
+ */
+static inline uint8_t VREF_GetP7TrimValue(VREF_Type *base)
+{
+    return (uint8_t)((base->TRIM0 & VREF_TRIM0_P7_TRIM_MASK) >> VREF_TRIM0_P7_TRIM_SHIFT);
+}
+
+/*!
+ * @brief Set VREF chop osc trim value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF chop osc trim value.
+ */
+static inline void VREF_SetChopOscTrimValue(VREF_Type *base, uint8_t value)
+{
+    base->TRIM0 = (base->TRIM0 & ~VREF_TRIM0_CHOPOSCTRIM_MASK) | VREF_TRIM0_CHOPOSCTRIM(value);
+}
+
+/*!
+ * @brief Get VREF chop osc trim value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF chop osc trim value.
+ */
+static inline uint8_t VREF_GetChopOscTrimValue(VREF_Type *base)
+{
+    return (uint8_t)((base->TRIM0 & VREF_TRIM0_CHOPOSCTRIM_MASK) >> VREF_TRIM0_CHOPOSCTRIM_SHIFT);
+}
+
+/*!
+ * @brief Set VREF bandgap MSB value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF bandgap MSB value.
+ */
+static inline void VREF_SetBandgapMsb(VREF_Type *base, uint8_t value)
+{
+    base->TRIM0 = (base->TRIM0 & ~VREF_TRIM0_BPMSB_MASK) | VREF_TRIM0_BPMSB(value);
+}
+
+/*!
+ * @brief Get VREF bandgap MSB value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF bandgap MSB value.
+ */
+static inline uint8_t VREF_GetBandgapMsb(VREF_Type *base)
+{
+    return (uint8_t)((base->TRIM0 & VREF_TRIM0_BPMSB_MASK) >> VREF_TRIM0_BPMSB_SHIFT);
+}
+
+/*!
+ * @brief Set VREF bandgap LSB value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF bandgap LSB value.
+ */
+static inline void VREF_SetBandgapLsb(VREF_Type *base, uint8_t value)
+{
+    base->TRIM0 = (base->TRIM0 & ~VREF_TRIM0_BPLSB_MASK) | VREF_TRIM0_BPLSB(value);
+}
+
+/*!
+ * @brief Get VREF bandgap LSB value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF bandgap LSB value.
+ */
+static inline uint8_t VREF_GetBandgapLsb(VREF_Type *base)
+{
+    return (uint8_t)((base->TRIM0 & VREF_TRIM0_BPLSB_MASK) >> VREF_TRIM0_BPLSB_SHIFT);
+}
+
+/*!
+ * @brief Set VREF temperature compensation MSB value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF temperature compensation MSB value.
+ */
+static inline void VREF_SetTempCompMsb(VREF_Type *base, uint8_t value)
+{
+    base->TRIM0 = (base->TRIM0 & ~VREF_TRIM0_COMPMSB_MASK) | VREF_TRIM0_COMPMSB(value);
+}
+
+/*!
+ * @brief Get VREF temperature compensation MSB value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF temperature compensation MSB value.
+ */
+static inline uint8_t VREF_GetTempCompMsb(VREF_Type *base)
+{
+    return (uint8_t)((base->TRIM0 & VREF_TRIM0_COMPMSB_MASK) >> VREF_TRIM0_COMPMSB_SHIFT);
+}
+
+/*!
+ * @brief Set VREF temperature compensation LSB value.
+ *
+ * @param base VREF peripheral address.
+ * @param value VREF temperature compensation LSB value.
+ */
+static inline void VREF_SetTempCompLsb(VREF_Type *base, uint8_t value)
+{
+    base->TRIM0 = (base->TRIM0 & ~VREF_TRIM0_COMPLSB_MASK) | VREF_TRIM0_COMPLSB(value);
+}
+
+/*!
+ * @brief Get VREF temperature compensation LSB value.
+ *
+ * @param base VREF peripheral address.
+ * @return VREF temperature compensation LSB value.
+ */
+static inline uint8_t VREF_GetTempCompLsb(VREF_Type *base)
+{
+    return (uint8_t)((base->TRIM0 & VREF_TRIM0_COMPLSB_MASK) >> VREF_TRIM0_COMPLSB_SHIFT);
+}
+#endif /* FSL_FEATURE_VREF_HAS_TRIM0_REG */
+
+/*! @} */
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+/*! @}*/
+
+#endif /* FSL_VREF_H_ */

--- a/frdmmcxn947_project_TCM LinkServer Debug.launch
+++ b/frdmmcxn947_project_TCM LinkServer Debug.launch
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="com.crt.dsfdebug.crtmcu.launchType">
+    <stringAttribute key=".gdbinit" value=""/>
+    <booleanAttribute key="attach" value="false"/>
+    <booleanAttribute key="boot.config.enable" value="false"/>
+    <stringAttribute key="boot.configuration.control" value=""/>
+    <stringAttribute key="bootrom.stall" value="0x50000040"/>
+    <stringAttribute key="com.crt.ctrlcenter.OFSemuDetails" value="LinkServer"/>
+    <booleanAttribute key="com.crt.ctrlcenter.crtInit" value="true"/>
+    <stringAttribute key="com.crt.ctrlcenter.currentWireType" value="SWD"/>
+    <booleanAttribute key="com.crt.ctrlcenter.mainBreakIsHardware" value="true"/>
+    <booleanAttribute key="com.crt.ctrlcenter.saveState" value="true"/>
+    <stringAttribute key="com.crt.ctrlcenter.serialNumber" value="LinkServerNXP SemiconductorsMCU-LINK FRDM-MCXN947 (r0E7) CMSIS-DAP V3.128FKEZSKAM34WYG"/>
+    <listAttribute key="com.crt.ctrlcenter.symbolsAndImagesGroupSettings"/>
+    <intAttribute key="com.crt.ctrlcenter.version" value="6"/>
+    <stringAttribute key="com.nxp.mcuxpresso.flash.base.address" value="0x0"/>
+    <booleanAttribute key="com.nxp.mcuxpresso.flash.clear.console" value="true"/>
+    <booleanAttribute key="com.nxp.mcuxpresso.flash.confirm" value="false"/>
+    <stringAttribute key="com.nxp.mcuxpresso.flash.erase.algorithm" value="Mass erase"/>
+    <stringAttribute key="com.nxp.mcuxpresso.flash.executable" value="axf"/>
+    <stringAttribute key="com.nxp.mcuxpresso.flash.program.action" value="Program"/>
+    <booleanAttribute key="com.nxp.mcuxpresso.flash.reset.target" value="true"/>
+    <stringAttribute key="com.nxp.mcuxpresso.ide.probe.manufacturer" value="NXP Semiconductors"/>
+    <stringAttribute key="com.nxp.mcuxpresso.ide.probe.name" value="MCU-LINK FRDM-MCXN947 (r0E7) CMSIS-DAP V3.128"/>
+    <stringAttribute key="com.nxp.mcuxpresso.ide.probe.type" value="LinkServer"/>
+    <stringAttribute key="debug.level" value="2"/>
+    <stringAttribute key="emu.speed" value=""/>
+    <stringAttribute key="flash.driver.reset" value=""/>
+    <stringAttribute key="gdbserver.host" value="localhost"/>
+    <stringAttribute key="gdbserver.port" value="10989"/>
+    <booleanAttribute key="gdbserver.start" value="true"/>
+    <booleanAttribute key="internal.attach.slave" value="false"/>
+    <booleanAttribute key="internal.cache" value="false"/>
+    <stringAttribute key="internal.connect.script" value=""/>
+    <stringAttribute key="internal.core.index" value=""/>
+    <booleanAttribute key="internal.has_swo" value="true"/>
+    <booleanAttribute key="internal.multi.swd" value="true"/>
+    <stringAttribute key="internal.prelaunch.command" value=""/>
+    <stringAttribute key="internal.reset.script" value=""/>
+    <stringAttribute key="internal.resethandling" value=""/>
+    <stringAttribute key="internal.semihost" value="On"/>
+    <stringAttribute key="internal.wirespeed" value=""/>
+    <stringAttribute key="internal.wiretype" value="SWD"/>
+    <stringAttribute key="isp.control" value="xxxx"/>
+    <stringAttribute key="launch.config.handler" value="com.crt.ctrlcenter.launch.CRTLaunchConfigHandler"/>
+    <booleanAttribute key="mem.access" value="false"/>
+    <stringAttribute key="misc.options" value=" --romstalldelay 600"/>
+    <stringAttribute key="ondisconnect" value="cont"/>
+    <intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.delay" value="0"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.doHalt" value="false"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.doReset" value="false"/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageFileName" value=""/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.imageOffset" value=""/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.initCommands" value="set non-stop on&#10;set pagination off&#10;set mi-async&#10;set remotetimeout 60000&#10;##target_extended_remote##&#10;set mem inaccessible-by-default ${mem.access}&#10;mon ondisconnect ${ondisconnect}&#10;set arm force-mode thumb&#10;${load}"/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.ipAddress" value="localhost"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadImage" value="true"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.loadSymbols" value="true"/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.pcRegister" value=""/>
+    <intAttribute key="org.eclipse.cdt.debug.gdbjtag.core.portNumber" value="10989"/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.runCommands" value="${run}"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setPcRegister" value="false"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setResume" value="false"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.setStopAt" value="true"/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.stopAt" value="main"/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsFileName" value=""/>
+    <stringAttribute key="org.eclipse.cdt.debug.gdbjtag.core.symbolsOffset" value=""/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForImage" value="false"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useFileForSymbols" value="false"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
+    <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
+    <stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
+    <booleanAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_ON_FORK" value="false"/>
+    <booleanAttribute key="org.eclipse.cdt.dsf.gdb.EXTERNAL_CONSOLE" value="false"/>
+    <stringAttribute key="org.eclipse.cdt.dsf.gdb.GDB_INIT" value=""/>
+    <booleanAttribute key="org.eclipse.cdt.dsf.gdb.NON_STOP" value="true"/>
+    <booleanAttribute key="org.eclipse.cdt.dsf.gdb.REVERSE" value="false"/>
+    <stringAttribute key="org.eclipse.cdt.dsf.gdb.REVERSE_MODE" value="UseSoftTrace"/>
+    <stringAttribute key="org.eclipse.cdt.dsf.gdb.TRACEPOINT_MODE" value="TP_NORMAL_ONLY"/>
+    <booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
+    <intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
+    <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_ID" value="gdb"/>
+    <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_START_MODE" value="remote"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="Debug\frdmmcxn947_project_TCM.axf"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="frdmmcxn947_project_TCM"/>
+    <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value="com.crt.advproject.config.exe.debug.91297413"/>
+    <booleanAttribute key="org.eclipse.cdt.launch.use_terminal" value="false"/>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/frdmmcxn947_project_TCM"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="4"/>
+    </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.preferred_launchers">
+        <mapEntry key="[debug]" value="com.nxp.mcuxpresso.core.debug.support.linkserver.launch.LinkServerGdbLaunch"/>
+    </mapAttribute>
+    <stringAttribute key="org.eclipse.dsf.launch.MEMORY_BLOCKS" value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&lt;memoryBlockExpressionList context=&quot;reserved-for-future-use&quot;/&gt;"/>
+    <stringAttribute key="process_factory_id" value="com.nxp.mcuxpresso.core.debug.override.MCXProcessFactory"/>
+    <booleanAttribute key="redlink.disable.preconnect.script" value="false"/>
+    <booleanAttribute key="redlink.enable.flashhashing" value="true"/>
+    <booleanAttribute key="redlink.enable.rangestepping" value="true"/>
+    <stringAttribute key="run" value="cont"/>
+    <booleanAttribute key="vector.catch" value="false"/>
+</launchConfiguration>


### PR DESCRIPTION
Habilite los pines para PWM, ya se probaron los GPIO como input y output, falta corregir configuraciones del ADC, pero ya están habilitados los pines, los del PWM también ya los probe y funcionan bien como canales independientes

<img width="1903" height="921" alt="image" src="https://github.com/user-attachments/assets/938ea751-cb9b-43e5-81ef-6191a2416554" />
